### PR TITLE
Kubernetes volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ## Домашние задания
 
-1. (Введение)[./kubernetes-intro/]
-2. (Безопасность)[./kuibernetes-security]
-3. (Обзор сетевой подсистемы)[./kubernetes-networks]
-4. (Volumes, Storages, Statefull)[./]
+1. [Введение](./kubernetes-intro/)
+2. [Безопасность](./kuibernetes-security)
+3. [Обзор сетевой подсистемы](./kubernetes-networks)
+4. [Volumes, Storages, Statefull](./kubernetes-volumes)
 

--- a/kubernetes-volumes/README.md
+++ b/kubernetes-volumes/README.md
@@ -1,1 +1,9 @@
 # Volumes, Storages, Statefull-приложения в Kubernetes #
+
+## Что сделано:
+
+1. Развернут кластер с помощью [kind](https://kind.sigs.k8s.io/docs/user/quick-start#installation)
+2. Установлена StatefulSet [конфигурация](https://raw.githubusercontent.com/express42/otus-platform-snippets/master/Module-02/Kuberenetes-volumes/minio-statefulset.yaml)
+3. Добавлен [Headless Service](https://raw.githubusercontent.com/express42/otus-platform-snippets/master/Module-02/Kuberenetes-volumes/minio-headless-service.yaml)
+4. Создан Secret и переконфигурирован StatefulSet на его использование
+

--- a/kubernetes-volumes/README.md
+++ b/kubernetes-volumes/README.md
@@ -1,0 +1,1 @@
+# Volumes, Storages, Statefull-приложения в Kubernetes #

--- a/kubernetes-volumes/minio-headless-service.yaml
+++ b/kubernetes-volumes/minio-headless-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  labels:
+    app: minio
+spec:
+  clusterIP: None
+  ports:
+    - port: 9000
+      name: minio
+  selector:
+    app: minio

--- a/kubernetes-volumes/minio-statefulset.yaml
+++ b/kubernetes-volumes/minio-statefulset.yaml
@@ -1,3 +1,14 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-user-pass
+type: Opaque
+data:
+  MINIO_ACCESS_KEY: bWluaW8=
+  MINIO_SECRET_KEY: bWluaW8xMjM=
+
+---
 apiVersion: apps/v1beta1
 kind: StatefulSet
 metadata:
@@ -18,9 +29,15 @@ spec:
       - name: minio
         env:
         - name: MINIO_ACCESS_KEY
-          value: "minio"
+          valueFrom:
+            secretKeyRef:
+              name: minio-user-pass
+              key: MINIO_ACCESS_KEY
         - name: MINIO_SECRET_KEY
-          value: "minio123"
+          valueFrom:
+            secretKeyRef:
+              name: minio-user-pass
+              key: MINIO_SECRET_KEY
         image: minio/minio:RELEASE.2019-07-10T00-34-56Z
         args:
         - server

--- a/kubernetes-volumes/minio-statefulset.yaml
+++ b/kubernetes-volumes/minio-statefulset.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  # This name uniquely identifies the StatefulSet
+  name: minio
+spec:
+  serviceName: minio
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio # has to match .spec.template.metadata.labels
+  template:
+    metadata:
+      labels:
+        app: minio # has to match .spec.selector.matchLabels
+    spec:
+      containers:
+      - name: minio
+        env:
+        - name: MINIO_ACCESS_KEY
+          value: "minio"
+        - name: MINIO_SECRET_KEY
+          value: "minio123"
+        image: minio/minio:RELEASE.2019-07-10T00-34-56Z
+        args:
+        - server
+        - /data 
+        ports:
+        - containerPort: 9000
+        # These volume mounts are persistent. Each pod in the PetSet
+        # gets a volume mounted based on this field.
+        volumeMounts:
+        - name: data
+          mountPath: /data
+        # Liveness probe detects situations where MinIO server instance
+        # is not working properly and needs restart. Kubernetes automatically
+        # restarts the pods if liveness checks fail.
+        livenessProbe:
+          httpGet:
+            path: /minio/health/live
+            port: 9000
+          initialDelaySeconds: 120
+          periodSeconds: 20
+  # These are converted to volume claims by the controller
+  # and mounted at the paths mentioned above.
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi


### PR DESCRIPTION
# Выполнено ДЗ №4
* Volumes, Storages, Statefull-приложения в Kubernetes *

## Что сделано:

1. Развернут кластер с помощью [kind](https://kind.sigs.k8s.io/docs/user/quick-start#installation)
2. Установлена StatefulSet [конфигурация](https://raw.githubusercontent.com/express42/otus-platform-snippets/master/Module-02/Kuberenetes-volumes/minio-statefulset.yaml)
3. Добавлен [Headless Service](https://raw.githubusercontent.com/express42/otus-platform-snippets/master/Module-02/Kuberenetes-volumes/minio-headless-service.yaml)
4. Создан Secret и переконфигурирован [StatefulSet](./minio-statefulset.yaml) на его использование

